### PR TITLE
feat(manager): add global message on site list page

### DIFF
--- a/manager/director/settings/__init__.py
+++ b/manager/director/settings/__init__.py
@@ -398,3 +398,8 @@ else:
     SHELL_ENCRYPTION_TOKEN_PUBLIC_KEY = import_rsa_key_from_file(
         SHELL_ENCRYPTION_TOKEN_PUBLIC_KEY_PATH
     )
+
+# A message to show on every page
+# If no message, leave as None
+GLOBAL_MESSAGE = None
+

--- a/manager/director/templates/sites/list.html
+++ b/manager/director/templates/sites/list.html
@@ -29,6 +29,11 @@
     {% endif %}
 
     <div class="subheading clearfix">
+        {% if DJANGO_SETTINGS.GLOBAL_MESSAGE %}
+            <div class="alert alert-warning">
+                {{ DJANGO_SETTINGS.GLOBAL_MESSAGE |safe }}
+            </div>
+        {% endif %}
         {% if query %}
         <h3 class="float-left d-none d-sm-block">Search Results From {% if show_all %}All{% else %}Your{% endif %} Sites</h3>
         {% else %}


### PR DESCRIPTION
We should probably have the functionality to put a message on the site listing page. Addresses a concern in #5.

This adds that functionality as `GLOBAL_MESSAGE` in the Django settings.

![image](https://user-images.githubusercontent.com/3579871/91078411-91e83180-e610-11ea-9052-1e828c9df83a.png)
