### PR TITLE
manager: add restart message to editor on ALT+ENTER

### DIFF
--- a/manager/director/static/js/site-editor/main.js
+++ b/manager/director/static/js/site-editor/main.js
@@ -274,6 +274,11 @@ $(function() {
 });
 
 function restartProcess() {
+    Messenger().info({
+        message: "Restarting server",
+        hideAfter: 5,
+        showCloseButton: true,
+    });
     $.post({
         url: restart_endpoint,
     }).fail(function(data) {


### PR DESCRIPTION
Currently, it isn't immediately clear when someone presses ALT + ENTER that the server process is restarting. Eventually, a message shows saying that the server is being stopped then started, but it isn't immediate.

This PR addresses that by adding a message "Restarting server" when the server is restarted.