### PR TITLE
feat(orchestrator): use a C program for terminal keepalives

### DIFF
--- a/orchestrator/orchestrator/files.py
+++ b/orchestrator/orchestrator/files.py
@@ -212,7 +212,7 @@ def stream_site_file(site_id: int, relpath: str) -> Generator[bytes, None, None]
     errors = proc.stderr.readline().strip().decode()
 
     # Was downloading the file (initially) successful?
-    success = (errors == "OK")
+    success = errors == "OK"
 
     selector = selectors.DefaultSelector()
     selector.register(proc.stdout, selectors.EVENT_READ)

--- a/orchestrator/orchestrator/settings/__init__.py
+++ b/orchestrator/orchestrator/settings/__init__.py
@@ -77,6 +77,11 @@ FILE_STREAM_BUFSIZE = 4096
 
 TIMEZONE = "America/New_York"
 
+# The path to the terminal keepalive program
+# Here, it is set to None, and is defined in secret.py
+# If set to None, it will use a sh script instead of a C program
+TERMINAL_KEEPALIVE_PROGRAM_PATH = None
+
 # Logging configuration
 LOG_LEVEL = logging.INFO
 LOG_FILE = None

--- a/orchestrator/orchestrator/terminal.py
+++ b/orchestrator/orchestrator/terminal.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 from docker.client import DockerClient
 from docker.errors import APIError, NotFound
 from docker.models.containers import Container
+from docker.types import Mount
 
 from . import settings
 from .docker import containers
@@ -84,15 +85,33 @@ class TerminalContainer:  # pylint: disable=too-many-instance-attributes
             self.client, self.site_id, self.site_data
         )
 
+        # Allows for the use of a C program to perform keepalive instead of
+        # using `sh`, better performance
+        if settings.TERMINAL_KEEPALIVE_PROGRAM_PATH is not None:
+            keepalive_command = [
+                "/terminal-keepalive",
+                str(settings.SITE_TERMINAL_KEEPALIVE_TIMEOUT),
+            ]
+            run_params.get("mounts").append(
+                Mount(
+                    "/terminal-keepalive",
+                    settings.TERMINAL_KEEPALIVE_PROGRAM_PATH,
+                    type="bind",
+                    read_only=True,
+                )
+            )
+        else:
+            keepalive_command = [
+                "sh",
+                "-c",
+                'while timeout "$1" head -n 1 &>/dev/null; do true; done',
+                "sh",
+                str(settings.SITE_TERMINAL_KEEPALIVE_TIMEOUT),
+            ]
+
         run_params.update(
             {
-                "command": [
-                    "sh",
-                    "-c",
-                    'while timeout "$1" head -n 1 &>/dev/null; do true; done',
-                    "sh",
-                    str(settings.SITE_TERMINAL_KEEPALIVE_TIMEOUT),
-                ],
+                "command": keepalive_command,
                 "read_only": True,
                 "auto_remove": True,
                 "stdin_open": True,

--- a/orchestrator/scripts/terminal-keepalive.c
+++ b/orchestrator/scripts/terminal-keepalive.c
@@ -1,0 +1,39 @@
+#include <unistd.h>
+#include <stdlib.h>
+#include <signal.h>
+
+/* For the definition of SYS_ioprio_set */
+#include <sys/syscall.h>
+
+/* Extracted from the kernel source */
+#define IOPRIO_WHO_PROCESS 1
+#define IOPRIO_CLASS_IDLE 3
+#define _IOPRIO_CLASS_SHIFT 13
+#define _IOPRIO_PRIO_MASK ((1 << _IOPRIO_CLASS_SHIFT) - 1)
+#define IOPRIO_PRIO_VALUE(cls, dat) (((cls) << _IOPRIO_CLASS_SHIFT) | ((dat) & _IOPRIO_PRIO_MASK))
+
+int main(int argc, char *argv[]) {
+    unsigned int timeout;
+    char c;
+
+    // Parse the timeout from the command line
+    timeout = (argc >= 2 ? atoi(argv[1]) : 120);
+
+    // Make sure that SIGALRM is set to use the default action (i.e. terminate the process)
+    signal(SIGALRM, SIG_DFL);
+
+    // Nice ourselves into the background
+    nice(40);
+    // Also lower the I/O priority
+    syscall(SYS_ioprio_set, IOPRIO_WHO_PROCESS, 0, IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0));
+
+    do {
+        // Set an alarm
+        alarm(timeout);
+
+        // Wait until we read a character from stdin before resetting the alarm
+    } while(read(0, &c, 1) == 1);
+
+    return 1;
+}
+


### PR DESCRIPTION
As discussed.

* Uses the C program in `orchestrator/scripts/terminal-keepalive.c` instead of the `sh -c` command to kill the terminal after a predefined timeout.

We'll need to compile and place the resulting binary in a place on all appservers and set the `TERMINAL_KEEPALIVE_PROGRAM_PATH` in `secret.py` to the location of that binary.