### PR TITLE
feat(orchestrator): use a C program for terminal keepalives

### DIFF
--- a/orchestrator/orchestrator/settings/__init__.py
+++ b/orchestrator/orchestrator/settings/__init__.py
@@ -77,6 +77,11 @@ FILE_STREAM_BUFSIZE = 4096
 
 TIMEZONE = "America/New_York"
 
+# The path to the terminal keepalive program
+# Here, it is set to None, and is defined in secret.py
+# If set to None, it will use a sh script instead of a C program
+TERMINAL_KEEPALIVE_PROGRAM_PATH = None
+
 # Logging configuration
 LOG_LEVEL = logging.INFO
 LOG_FILE = None

--- a/orchestrator/scripts/terminal-keepalive.c
+++ b/orchestrator/scripts/terminal-keepalive.c
@@ -1,0 +1,39 @@
+#include <unistd.h>
+#include <stdlib.h>
+#include <signal.h>
+
+/* For the definition of SYS_ioprio_set */
+#include <sys/syscall.h>
+
+/* Extracted from the kernel source */
+#define IOPRIO_WHO_PROCESS 1
+#define IOPRIO_CLASS_IDLE 3
+#define _IOPRIO_CLASS_SHIFT 13
+#define _IOPRIO_PRIO_MASK ((1 << _IOPRIO_CLASS_SHIFT) - 1)
+#define IOPRIO_PRIO_VALUE(cls, dat) (((cls) << _IOPRIO_CLASS_SHIFT) | ((dat) & _IOPRIO_PRIO_MASK))
+
+int main(int argc, char *argv[]) {
+    unsigned int timeout;
+    char c;
+
+    // Parse the timeout from the command line
+    timeout = (argc >= 2 ? atoi(argv[1]) : 120);
+
+    // Make sure that SIGALRM is set to use the default action (i.e. terminate the process)
+    signal(SIGALRM, SIG_DFL);
+
+    // Nice ourselves into the background
+    nice(40);
+    // Also lower the I/O priority
+    syscall(SYS_ioprio_set, IOPRIO_WHO_PROCESS, 0, IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0));
+
+    do {
+        // Set an alarm
+        alarm(timeout);
+
+        // Wait until we read a character from stdin before resetting the alarm
+    } while(read(0, &c, 1) == 1);
+
+    return 1;
+}
+


### PR DESCRIPTION
As discussed.

* Uses the C program in `orchestrator/scripts/terminal-keepalive.c` instead of the `sh -c` command to kill the terminal after a predefined timeout.

We'll need to compile and place the resulting binary in a place on all appservers and set the `TERMINAL_KEEPALIVE_PROGRAM_PATH` in `secret.py` to the location of that binary.