### PR TITLE
fix(manager): remove Docker service on disabled site

### DIFF
--- a/manager/director/apps/sites/actions.py
+++ b/manager/director/apps/sites/actions.py
@@ -108,6 +108,10 @@ def remove_appserver_nginx_config(
 def update_docker_service(
     site: Site, scope: Dict[str, Any]
 ) -> Iterator[Union[Tuple[str, str], str]]:
+    if site.availability == "disabled":
+        yield from remove_docker_service(site, scope)
+        return
+
     appserver = random.choice(scope["pingable_appservers"])
 
     yield "Connecting to appserver {} to create/update Docker service".format(appserver)
@@ -124,6 +128,10 @@ def update_docker_service(
 def restart_docker_service(
     site: Site, scope: Dict[str, Any]
 ) -> Iterator[Union[Tuple[str, str], str]]:
+    if site.availability == "disabled":
+        yield "Site disabled; skipping"
+        return
+
     appserver = random.choice(scope["pingable_appservers"])
 
     yield "Connecting to appserver {} to restart Docker service".format(appserver)


### PR DESCRIPTION
Properly removes the Docker service on a disabled site.

Also, I'm not quite sure if we want to do this, but currently, if one were to restart the process on a disabled site, the task would error out. It may be helpful to keep the error so that users are not confused, but at the same time, they could no longer make edits to their image and they would have to ask for help.