### PR TITLE
feat(manager): add loading message to files pane

### DIFF
--- a/manager/director/static/css/site-editor/files-pane.css
+++ b/manager/director/static/css/site-editor/files-pane.css
@@ -18,6 +18,14 @@
     opacity: 0.5;
 }
 
+.files-pane > .items.disabled > .children:empty::before {
+    content: "Loading...";
+    margin-left: 10px;
+    color: black;
+    font-style: italic;
+}
+
+
 .files-pane .root-drop-container {
     flex: 1 1;
     min-height: 30px;


### PR DESCRIPTION
Adds a "loading" message to the files pane when it is loading.

![image](https://user-images.githubusercontent.com/3579871/99995991-1faaf880-2d89-11eb-8481-f2338473dbb6.png)

See #41