### PR TITLE
feat(manager): allow superusers to start sites with numbers

### DIFF
--- a/manager/director/apps/sites/forms.py
+++ b/manager/director/apps/sites/forms.py
@@ -64,6 +64,7 @@ class SiteCreateForm(forms.ModelForm):
         if (
             cleaned_data["name"][0] in string.digits
             and cleaned_data.get("purpose", self.initial_purpose) != "user"
+            and not self.user.is_superuser
         ):
             self.add_error("name", "Project site names cannot start with a number")
 


### PR DESCRIPTION
Superusers should be able to create project sites that start with numbers.