### PR TITLE
fix(orchestrator): add update to dockerfile template

### DIFF
--- a/orchestrator/orchestrator/docker/templates/Dockerfile
+++ b/orchestrator/orchestrator/docker/templates/Dockerfile
@@ -8,5 +8,6 @@ RUN {{ parent_setup_command }}
 {% endif %}
 
 {% if install_command -%}
+RUN apt-get --allow-releaseinfo-change update -y
 RUN {{ install_command }}
 {% endif %}


### PR DESCRIPTION
Building images breaks with several distros and packages, i.e. python-3.8:buster and redis