### PR TITLE
fix(manager): allow periods in package names

### DIFF
--- a/manager/director/apps/sites/forms.py
+++ b/manager/director/apps/sites/forms.py
@@ -231,7 +231,7 @@ class ImageSelectForm(forms.Form):
         help_text="This should be a space-separated list of packages to install in the image.",
     )
 
-    PACKAGE_NAME_REGEX = re.compile(r"^[a-zA-Z0-9_][-+=_a-zA-Z0-9]*$")
+    PACKAGE_NAME_REGEX = re.compile(r"^[a-zA-Z0-9_][-+=_.a-zA-Z0-9]*$")
 
     def clean(self) -> Dict[str, Any]:
         cleaned_data = super().clean()


### PR DESCRIPTION
### Rationale
The package name regex does not allow periods in package names. However, some packages i.e. `python3.12` have periods in them