### PR TITLE
Deployment Bugfixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
     vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
     vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
     vb.name = "director4-vagrant"
-    vb.memory = 2048
+    vb.memory = ENV.fetch("DIRECTOR4_VAGRANT_MEMORY", 2048).to_i
   end
 
   # Sync this repo to /home/vagrant/director

--- a/manager/director/apps/sites/actions.py
+++ b/manager/director/apps/sites/actions.py
@@ -4,12 +4,14 @@
 import asyncio
 import json
 import random
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, AsyncGenerator, Dict, Iterator, Tuple, Union
 
 from django.conf import settings
 
 from ...utils.appserver import (
     AppserverProtocolError,
+    AppserverRequestError,
     appserver_open_http_request,
     appserver_open_websocket,
     iter_pingable_appservers,
@@ -17,6 +19,39 @@ from ...utils.appserver import (
 from ...utils.balancer import balancer_open_http_request, iter_pingable_balancers
 from ...utils.secret_generator import gen_database_password
 from .models import Domain, Site
+
+
+def reload_nginx_on_appservers(
+    appservers: Iterator[int],
+    *,
+    timeout: Union[int, float] = 180,
+) -> None:
+    appserver_list = list(appservers)
+    if not appserver_list:
+        return
+
+    errors = []
+
+    with ThreadPoolExecutor(max_workers=len(appserver_list)) as executor:
+        future_map = {
+            executor.submit(
+                appserver_open_http_request,
+                appserver,
+                "/sites/reload-nginx",
+                method="POST",
+                timeout=timeout,
+            ): appserver
+            for appserver in appserver_list
+        }
+
+        for future, appserver in future_map.items():
+            try:
+                future.result()
+            except AppserverRequestError as ex:
+                errors.append("appserver {}: {}: {}".format(appserver, ex.__class__.__name__, ex))
+
+    if errors:
+        raise AppserverProtocolError("; ".join(errors))
 
 
 def find_pingable_appservers(  # pylint: disable=unused-argument
@@ -44,9 +79,9 @@ def update_appserver_nginx_config(
             data={"data": json.dumps(site.serialize_for_appserver())},
             timeout=60,
         )
-    except AppserverProtocolError:
+    except AppserverRequestError as ex:
         # If an error occurs, disable the Nginx config
-        yield "Error updating Nginx config"
+        yield "Error updating Nginx config: {}: {}".format(ex.__class__.__name__, ex)
 
         yield "Disabling site Nginx config"
         appserver_open_http_request(
@@ -66,17 +101,11 @@ def update_appserver_nginx_config(
         try:
             for i in scope["pingable_appservers"]:
                 yield "Reloading Nginx config on appserver {}".format(i)
-
-                appserver_open_http_request(
-                    i,
-                    "/sites/reload-nginx",
-                    method="POST",
-                    timeout=120,
-                )
-        except AppserverProtocolError:
+            reload_nginx_on_appservers(scope["pingable_appservers"], timeout=180)
+        except AppserverRequestError as ex:
             # Error reloading; disable config
             # We're probably fine not reloading Nginx
-            yield "Error reloading Nginx config"
+            yield "Error reloading Nginx config: {}: {}".format(ex.__class__.__name__, ex)
 
             yield "Disabling site Nginx config"
             appserver_open_http_request(
@@ -109,13 +138,7 @@ def remove_appserver_nginx_config(
     yield "Reloading Nginx config on all appservers"
     for i in scope["pingable_appservers"]:
         yield "Reloading Nginx config on appserver {}".format(i)
-
-        appserver_open_http_request(
-            i,
-            "/sites/reload-nginx",
-            method="POST",
-            timeout=120,
-        )
+    reload_nginx_on_appservers(scope["pingable_appservers"], timeout=180)
 
     yield "Done"
 

--- a/manager/director/apps/sites/consumers.py
+++ b/manager/director/apps/sites/consumers.py
@@ -405,6 +405,8 @@ class SiteMonitorConsumer(AsyncWebsocketConsumer):
         self.connected = False
 
         self.monitor_websocks: List[WebSocketClientProtocol] = []
+        self.pending_browser_messages: List[Union[str, bytes]] = []
+        self.monitor_connections_initialized = False
 
     async def connect(self) -> None:
         if not self.scope["user"].is_authenticated:
@@ -426,38 +428,45 @@ class SiteMonitorConsumer(AsyncWebsocketConsumer):
 
         self.connected = True
         await self.accept()
+        asyncio.get_event_loop().create_task(self.initialize_monitor_connections())
 
+    async def initialize_monitor_connections(self) -> None:
         await self.open_monitor_connections()
 
-        if self.monitor_websocks:
-            loop = asyncio.get_event_loop()
-            for monitor_websock in self.monitor_websocks:
-                loop.create_task(self.monitor_mainloop(monitor_websock))
+        if not self.connected:
+            return
 
+        if self.monitor_websocks:
             # If we've connected to all the appservers, trigger a close after 1 hour.
             # Otherwise, trigger it after 5 minutes (so if an appserver comes back online soon
             # we get reconnected soon).
-            loop.create_task(
+            asyncio.get_event_loop().create_task(
                 self.sleep_and_close(
                     3600 if len(self.monitor_websocks) == settings.DIRECTOR_NUM_APPSERVERS else 300
                 )
             )
+            self.monitor_connections_initialized = True
+            self.pending_browser_messages.clear()
         else:
             self.connected = False
-            await self.close()
+            await self.close_monitor()
 
     async def sleep_and_close(self, timeout: Union[int, float]) -> None:
         await asyncio.sleep(timeout)
+        await self.close_monitor()
+
+    async def close_monitor(self) -> None:
         await self.close()
 
     async def open_monitor_connections(self) -> None:
         assert self.site is not None
+        site_id = self.site.id
 
         for appserver_num in iter_pingable_appservers():
             try:
                 monitor_websock = await asyncio.wait_for(
                     appserver_open_websocket(
-                        appserver_num, "/ws/sites/{}/files/monitor".format(self.site.id)
+                        appserver_num, "/ws/sites/{}/files/monitor".format(site_id)
                     ),
                     timeout=1,
                 )
@@ -465,6 +474,13 @@ class SiteMonitorConsumer(AsyncWebsocketConsumer):
                 pass
             else:
                 self.monitor_websocks.append(monitor_websock)
+                asyncio.get_event_loop().create_task(self.monitor_mainloop(monitor_websock))
+                if self.pending_browser_messages:
+                    for data in self.pending_browser_messages:
+                        try:
+                            await monitor_websock.send(data)
+                        except websocket_exceptions.ConnectionClosed:
+                            break
 
     async def monitor_mainloop(
         self,
@@ -474,20 +490,31 @@ class SiteMonitorConsumer(AsyncWebsocketConsumer):
             try:
                 msg = await monitor_websock.recv()
             except websocket_exceptions.ConnectionClosed:
-                await self.close()
+                if monitor_websock in self.monitor_websocks:
+                    self.monitor_websocks.remove(monitor_websock)
+                if not self.monitor_websocks:
+                    await self.close_monitor()
                 break
 
             if isinstance(msg, bytes):
-                await self.send(bytes_data=msg)
+                try:
+                    await self.send(bytes_data=msg)
+                except Exception:  # pylint: disable=broad-except
+                    await self.close_monitor()
+                    break
             elif isinstance(msg, str):
-                await self.send(text_data=msg)
+                try:
+                    await self.send(text_data=msg)
+                except Exception:  # pylint: disable=broad-except
+                    await self.close_monitor()
+                    break
 
     async def site_updated(self, event: Dict[str, Any]) -> None:  # pylint: disable=unused-argument
         if self.site is not None:
             await database_sync_to_async(self.site.refresh_from_db)()
 
             if not database_sync_to_async(self.site.can_be_edited_by)(self.scope["user"]):
-                await self.close()
+                await self.close_monitor()
 
     async def operation_updated(
         self, event: Dict[str, Any]  # pylint: disable=unused-argument
@@ -511,10 +538,13 @@ class SiteMonitorConsumer(AsyncWebsocketConsumer):
                 return
 
             try:
-                for monitor_websock in self.monitor_websocks:
+                if not self.monitor_connections_initialized:
+                    self.pending_browser_messages.append(data)
+
+                for monitor_websock in list(self.monitor_websocks):
                     await monitor_websock.send(data)
             except websocket_exceptions.ConnectionClosed:
-                await self.close()
+                await self.close_monitor()
 
 
 class SiteLogsConsumer(AsyncWebsocketConsumer):

--- a/manager/director/apps/sites/helpers.py
+++ b/manager/director/apps/sites/helpers.py
@@ -2,6 +2,7 @@
 # (c) 2019 The TJHSST Director 4.0 Development Team & Contributors
 
 import contextlib
+import logging
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union, overload
 
 from asgiref.sync import async_to_sync
@@ -13,6 +14,7 @@ from ...utils.emails import send_email
 from .models import Action, Operation, Site
 
 ActionCallback = Callable[[Site, Dict[str, Any]], Iterator[Union[Tuple[str, str], str]]]
+logger = logging.getLogger(__name__)
 
 
 class OperationWrapper:
@@ -86,6 +88,12 @@ class OperationWrapper:
             try:
                 self.run_action(action, callback, scope, new_action_callback=new_action_callback)
             except BaseException as ex:  # pylint: disable=broad-except
+                logger.exception(
+                    "Site operation %s failed during action %s for site %s",
+                    self.operation.type,
+                    action.slug,
+                    self.site.id,
+                )
                 action.message += "{}: {}\nScope: {}".format(ex.__class__.__name__, ex, scope)
                 action.result = False
                 action.save()

--- a/manager/director/apps/sites/tests/test_actions.py
+++ b/manager/director/apps/sites/tests/test_actions.py
@@ -57,11 +57,14 @@ class ActionsTestCase(DirectorTestCase):
 
             # "director-apptest1:8000" obviously isn't pingable.
             self.assertEqual("Connecting to appserver 0 to update Nginx config", next(result))
-            self.assertEqual("Error updating Nginx config", next(result))
+            self.assertIn(
+                "Error updating Nginx config: AppserverProtocolError:",
+                next(result),
+            )
             self.assertEqual("Disabling site Nginx config", next(result))
 
             with self.assertRaises(AppserverProtocolError):
-                self.assertEqual("Re-raising exception", next(result))
+                next(result)
 
         # Now, patch that method to bypass it
         with patch(

--- a/manager/director/settings/__init__.py
+++ b/manager/director/settings/__init__.py
@@ -197,7 +197,7 @@ CELERY_IMPORTS = ["director.utils.emails"]
 CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
-        "CONFIG": {"hosts": [{"address": ("127.0.0.1", 6379), "db": 0}], "prefix": "asgi:"},
+        "CONFIG": {"hosts": ["redis://127.0.0.1:6379/0"], "prefix": "asgi:"},
     }
 }
 

--- a/manager/director/utils/appserver.py
+++ b/manager/director/utils/appserver.py
@@ -3,6 +3,7 @@
 
 import http.client
 import json
+import logging
 import random
 import re
 import socket
@@ -19,6 +20,7 @@ from django.conf import settings
 from directorutil.ssl_context import create_internal_client_ssl_context
 
 appserver_ssl_context = create_internal_client_ssl_context(settings.DIRECTOR_APPSERVER_SSL)
+logger = logging.getLogger(__name__)
 
 
 class AppserverRequestError(Exception):
@@ -198,7 +200,15 @@ def appserver_open_http_request(
     try:
         response = urllib.request.urlopen(request, timeout=timeout, context=appserver_ssl_context)
     except urllib.error.HTTPError as ex:
-        raise AppserverProtocolError(ex.read().decode()) from ex
+        body = ex.read().decode(errors="replace")
+        logger.exception(
+            "Appserver HTTP error for %s %s: status=%s body=%r",
+            method,
+            full_url,
+            ex.code,
+            body,
+        )
+        raise AppserverProtocolError(body) from ex
     except urllib.error.URLError as ex:
         if isinstance(ex.reason, ConnectionError):
             raise AppserverConnectionError(str(ex)) from ex
@@ -206,6 +216,7 @@ def appserver_open_http_request(
         if isinstance(ex.reason, socket.timeout):
             raise AppserverTimeoutError(str(ex)) from ex
 
+        logger.exception("Appserver URL error for %s %s", method, full_url)
         raise AppserverProtocolError(str(ex)) from ex
     except socket.timeout as ex:
         raise AppserverTimeoutError(str(ex)) from ex

--- a/orchestrator/helpers/files-helper.py
+++ b/orchestrator/helpers/files-helper.py
@@ -566,6 +566,10 @@ def main(argv: List[str]) -> None:
 VENDOR_PREFIX = "ORCHESTRATOR_HELPER_VENDOR_"
 
 
+def _encode_vendor_module_env_name(name: str) -> str:
+    return name.replace(".", "__DOT__")
+
+
 class OrchestratorHelperVendorLoader:
     """Execute vendored module source pulled from environment variables."""
 
@@ -588,10 +592,18 @@ class OrchestratorHelperVendorFinder:
     """Resolve vendored modules/packages from ORCHESTRATOR_HELPER_VENDOR_* keys."""
 
     def find_spec(self, fullname: str, path=None, target=None):  # type: ignore[override]
-        for key in (VENDOR_PREFIX + fullname, VENDOR_PREFIX + fullname + ".__init__"):
+        encoded_package_key = VENDOR_PREFIX + _encode_vendor_module_env_name(fullname + ".__init__")
+        package_key = VENDOR_PREFIX + fullname + ".__init__"
+
+        for key in (
+            VENDOR_PREFIX + _encode_vendor_module_env_name(fullname),
+            encoded_package_key,
+            VENDOR_PREFIX + fullname,
+            package_key,
+        ):
             if key in os.environ:
                 text = os.environ[key]
-                is_package = key.endswith(".__init__")
+                is_package = key in {encoded_package_key, package_key}
                 loader = OrchestratorHelperVendorLoader(fullname, text, is_package)
                 return importlib.util.spec_from_loader(fullname, loader, is_package=is_package)
         return None

--- a/orchestrator/orchestrator/app.py
+++ b/orchestrator/orchestrator/app.py
@@ -20,6 +20,15 @@ app.register_blueprint(database_blueprint)
 
 app.config.update(settings.FLASK_CONFIG)
 
+
+def _copy_logger_handlers(target_logger: logging.Logger, source_logger: logging.Logger) -> None:
+    existing_handler_ids = {id(handler) for handler in target_logger.handlers}
+    for handler in source_logger.handlers:
+        if id(handler) not in existing_handler_ids:
+            target_logger.addHandler(handler)
+            existing_handler_ids.add(id(handler))
+
+
 if settings.LOG_FILE is not None:
     file_handler = logging.handlers.RotatingFileHandler(
         settings.LOG_FILE,
@@ -30,6 +39,24 @@ if settings.LOG_FILE is not None:
     file_handler.setLevel(settings.LOG_LEVEL)
 
     app.logger.addHandler(file_handler)  # pylint: disable=no-member
+else:
+    gunicorn_error_logger = logging.getLogger("gunicorn.error")
+    if gunicorn_error_logger.handlers:
+        app.logger.handlers = gunicorn_error_logger.handlers  # pylint: disable=no-member
+        app.logger.setLevel(gunicorn_error_logger.level)
+    else:
+        stream_handler = logging.StreamHandler()
+        stream_handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)-8s]: %(message)s"))
+        stream_handler.setLevel(settings.LOG_LEVEL)
+        app.logger.addHandler(stream_handler)  # pylint: disable=no-member
+        app.logger.setLevel(settings.LOG_LEVEL)
+
+gunicorn_access_logger = logging.getLogger("gunicorn.access")
+if gunicorn_access_logger.handlers:
+    _copy_logger_handlers(app.logger, gunicorn_access_logger)  # pylint: disable=no-member
+    app.logger.setLevel(min(app.logger.level, gunicorn_access_logger.level))
+
+app.logger.propagate = False  # pylint: disable=no-member
 
 
 @app.route("/ping")

--- a/orchestrator/orchestrator/database.py
+++ b/orchestrator/orchestrator/database.py
@@ -7,6 +7,7 @@ from typing import Any, ContextManager, Dict, Optional
 
 import MySQLdb
 import psycopg2
+from psycopg2 import errorcodes
 from psycopg2 import sql as psql
 
 
@@ -104,6 +105,40 @@ def open_site_cursor(database_info: Dict[str, Any]) -> ContextManager[Any]:
     )
 
 
+def _drop_postgres_database_force(cursor: Any, db_name: str) -> None:
+    try:
+        cursor.execute(
+            psql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(psql.Identifier(db_name))
+        )
+    except psycopg2.Error as ex:
+        if ex.pgcode not in {
+            errorcodes.SYNTAX_ERROR,
+            errorcodes.FEATURE_NOT_SUPPORTED,
+            errorcodes.OBJECT_IN_USE,
+        }:
+            raise
+
+        cursor.execute("SELECT 1 FROM pg_database WHERE datname = %s", (db_name,))
+        if cursor.rowcount == 0:
+            return
+
+        cursor.execute(
+            psql.SQL("ALTER DATABASE {} WITH ALLOW_CONNECTIONS false").format(
+                psql.Identifier(db_name)
+            )
+        )
+        cursor.execute(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = %s
+              AND pid <> pg_backend_pid();
+            """,
+            (db_name,),
+        )
+        cursor.execute(psql.SQL("DROP DATABASE IF EXISTS {}").format(psql.Identifier(db_name)))
+
+
 def create_database(database_info: Dict[str, Any]) -> None:
     if database_info["db_type"] == "postgres":
         with open_admin_cursor(database_info["host"], dbname="postgres") as cursor:
@@ -188,11 +223,7 @@ def create_database(database_info: Dict[str, Any]) -> None:
 def delete_database(database_info: Dict[str, Any]) -> None:
     if database_info["db_type"] == "postgres":
         with open_admin_cursor(database_info["host"], dbname="postgres") as cursor:
-            cursor.execute(
-                psql.SQL("DROP DATABASE IF EXISTS {}").format(
-                    psql.Identifier(database_info["db_name"])
-                )
-            )
+            _drop_postgres_database_force(cursor, database_info["db_name"])
 
             cursor.execute(
                 psql.SQL("REVOKE ALL ON SCHEMA public FROM {}").format(

--- a/orchestrator/orchestrator/docker/services.py
+++ b/orchestrator/orchestrator/docker/services.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # (c) 2019 The TJHSST Director 4.0 Development Team & Contributors
 
+import time
 from typing import Any, Dict, List, Optional, cast
 
 import docker
@@ -13,6 +14,27 @@ from ..exceptions import OrchestratorActionError
 from .conversions import convert_cpu_limit, convert_memory_limit
 from .shared import gen_director_shared_params
 from .utils import get_swarm_node_id
+
+
+def _wait_for_exec_exit_code(client: DockerClient, exec_id: str) -> int:
+    start = time.monotonic()
+    deadline = start + settings.NGINX_RELOAD_TIMEOUT
+
+    while True:
+        exec_info = cast(Dict[str, Any], client.api.exec_inspect(exec_id))
+
+        if not exec_info["Running"]:
+            return cast(int, exec_info["ExitCode"])
+
+        if time.monotonic() >= deadline:
+            elapsed = time.monotonic() - start
+            raise OrchestratorActionError(
+                "Timed out reloading Nginx config after {:.1f}s (exec_id={})".format(
+                    elapsed, exec_id
+                )
+            )
+
+        time.sleep(settings.NGINX_RELOAD_POLL_INTERVAL)
 
 
 def get_service_by_name(client: DockerClient, service_name: str) -> Optional[Service]:
@@ -160,6 +182,8 @@ def list_service_tasks_for_node(service: Service, node_id: str) -> List[Dict[str
 
 def reload_nginx_config(client: DockerClient) -> None:
     service = get_service_by_name(client, settings.NGINX_SERVICE_NAME)
+    if service is None:
+        raise OrchestratorActionError("Nginx service does not exist")
 
     node_id = get_swarm_node_id(client)
     tasks = list_service_tasks_for_node(service, node_id=node_id)
@@ -170,20 +194,29 @@ def reload_nginx_config(client: DockerClient) -> None:
 
             container = client.containers.get(container_id)
 
-            exit_code, _ = container.exec_run(
-                ["nginx", "-s", "reload"],
-                stdout=False,
-                stderr=True,
-                stdin=False,
-                tty=False,
-                privileged=False,
-                user="root",
-                detach=False,
-                stream=False,
-                socket=False,
-                workdir="/",
-                demux=False,
+            exec_id = cast(
+                str,
+                client.api.exec_create(
+                    container.id,
+                    ["nginx", "-s", "reload"],
+                    stdin=False,
+                    stdout=False,
+                    stderr=True,
+                    tty=False,
+                    privileged=False,
+                    user="root",
+                    workdir="/",
+                )["Id"],
             )
+
+            client.api.exec_start(
+                exec_id,
+                tty=False,
+                detach=True,
+                socket=False,
+            )
+
+            exit_code = _wait_for_exec_exit_code(client, exec_id)
 
             if exit_code != 0:
                 raise OrchestratorActionError("Error reloading Nginx config")

--- a/orchestrator/orchestrator/files.py
+++ b/orchestrator/orchestrator/files.py
@@ -98,6 +98,11 @@ def _load_vendor_modules(path: str) -> Iterable[Tuple[str, str]]:
                 yield (fname + "." + name, text)
 
 
+def _encode_vendor_module_env_name(name: str) -> str:
+    """Map module names to sudo-safe environment variable suffixes."""
+    return name.replace(".", "__DOT__")
+
+
 def _run_helper_script_prog(
     callback: Callable[[List[str], Dict[str, Any]], T], args: List[str], kwargs: Dict[str, Any]
 ) -> T:
@@ -124,7 +129,7 @@ def _run_helper_script_prog(
     kwargs["env"]["ORCHESTRATOR_HELPER_PROG"] = text
 
     for name, text in _load_vendor_modules(HELPER_SCRIPT_VENDOR_PATH):
-        kwargs["env"]["ORCHESTRATOR_HELPER_VENDOR_" + name] = text
+        kwargs["env"]["ORCHESTRATOR_HELPER_VENDOR_" + _encode_vendor_module_env_name(name)] = text
 
     # See docs/UMASK.md before touching this
     kwargs["env"]["ORCHESTRATOR_HELPER_UMASK"] = oct(settings.SITE_UMASK)
@@ -162,7 +167,7 @@ def ensure_site_directories_exist(site_id: int) -> None:
             *settings.SITE_DIRECTORY_COMMAND_PREFIX,
             "sh",
             "-c",
-            'umask "$1" && mkdir -p -- "$2"',
+            'umask "$1" && exec mkdir -p -- "$2"',
             "sh",
             oct(settings.SITE_UMASK)[2:],
             site_dir,

--- a/orchestrator/orchestrator/settings/__init__.py
+++ b/orchestrator/orchestrator/settings/__init__.py
@@ -28,6 +28,12 @@ DOCKER_REGISTRY_AUTH_CONFIG = {"username": "user", "password": "user"}
 # API
 DOCKER_REGISTRY_TIMEOUT = 20
 
+# Maximum amount of time to wait for an in-container nginx reload command to finish.
+NGINX_RELOAD_TIMEOUT = 180
+
+# How frequently to poll the Docker exec status for nginx reload
+NGINX_RELOAD_POLL_INTERVAL = 0.1
+
 # "Maintainer" of custom docker images
 DOCKER_IMAGE_MAINTAINER = "CSL"
 

--- a/orchestrator/orchestrator/views/database.py
+++ b/orchestrator/orchestrator/views/database.py
@@ -2,7 +2,6 @@
 # (c) 2019 The TJHSST Director 4.0 Development Team & Contributors
 
 import json
-import traceback
 from typing import Tuple, Union
 
 from flask import Blueprint, current_app, request
@@ -20,7 +19,12 @@ def create_database_page() -> Union[str, Tuple[str, int]]:
     try:
         database_utils.create_database(json.loads(request.form["data"]))
     except BaseException:  # pylint: disable=broad-except
-        current_app.logger.error("%s", traceback.format_exc())
+        current_app.logger.exception(
+            "Error creating site database for path=%s remote_addr=%s content_length=%s",
+            request.path,
+            request.remote_addr,
+            request.content_length,
+        )
         return "Error", 500
     else:
         return "Success"
@@ -34,7 +38,12 @@ def delete_database_page() -> Union[str, Tuple[str, int]]:
     try:
         database_utils.delete_database(json.loads(request.form["data"]))
     except BaseException:  # pylint: disable=broad-except
-        current_app.logger.error("%s", traceback.format_exc())
+        current_app.logger.exception(
+            "Error deleting site database for path=%s remote_addr=%s content_length=%s",
+            request.path,
+            request.remote_addr,
+            request.content_length,
+        )
         return "Error", 500
     else:
         return "Success"
@@ -53,5 +62,10 @@ def query_database_page() -> Union[str, Tuple[str, int]]:
             json.loads(request.form["database_info"]), request.form["sql"]
         )
     except BaseException:  # pylint: disable=broad-except
-        current_app.logger.error("%s", traceback.format_exc())
+        current_app.logger.exception(
+            "Error running site database query for path=%s remote_addr=%s content_length=%s",
+            request.path,
+            request.remote_addr,
+            request.content_length,
+        )
         return "Error", 500

--- a/shell/shell/tests/test_shell.py
+++ b/shell/shell/tests/test_shell.py
@@ -1,5 +1,6 @@
 import asyncio
 import multiprocessing
+import socket
 import time
 import unittest
 
@@ -7,6 +8,21 @@ import asyncssh
 from asyncssh import PermissionDenied
 
 from ..main import main
+
+
+def wait_for_port(host: str, port: int, process: multiprocessing.Process) -> None:
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if not process.is_alive():
+            raise AssertionError("Shell server process exited before accepting connections")
+
+        try:
+            with socket.create_connection((host, port), timeout=0.1):
+                return
+        except OSError:
+            time.sleep(0.1)
+
+    raise AssertionError("Timed out waiting for shell server to accept connections")
 
 
 class ShellTest(unittest.TestCase):
@@ -24,7 +40,7 @@ class ShellTest(unittest.TestCase):
     def test_ssh_connection(self) -> None:
         process = multiprocessing.Process(target=main, name="main", args=("m",))
         process.start()
-        time.sleep(0.5)
+        wait_for_port("127.0.0.1", 2322, process)
 
         # Try to connect as "root"
 

--- a/vagrant-config/provision.sh
+++ b/vagrant-config/provision.sh
@@ -117,8 +117,8 @@ run_psql_db() {
     sudo -u postgres psql -U postgres -d "$dbname" -c "$@"
 }
 for name in 'manager'; do
-    run_psql "CREATE DATABASE $name OWNER $name;" || echo "Database '$name' already exists"
     run_psql "CREATE USER $name PASSWORD 'pwd';" || echo "User '$name' already exists"
+    run_psql "CREATE DATABASE $name OWNER $name;" || echo "Database '$name' already exists"
 done
 
 run_psql "ALTER USER postgres WITH PASSWORD 'pwd';"
@@ -269,7 +269,7 @@ echo "user" | docker login localhost:4433 --username user --password-stdin
 docker service rm director-postgres || true
 docker service create --replicas=1 \
     --publish published=5433,target=5432 \
-    --mount type=bind,source=/data/db/postgres,destination=/var/lib/postgresql/data \
+    --mount type=bind,source=/data/db/postgres,destination=/var/lib/postgresql \
     --env=POSTGRES_USER=postgres \
     --env=POSTGRES_PASSWORD=pwd \
     --network director-sites \


### PR DESCRIPTION
Patches created after the original Python and Django bump was deployed into production. (The code in this PR has already been deployed to patch the production environment).
Includes:

- Improved logging for Appserver site operation errors (finally!)
- Normalization of env vars without "." and old-to-new redis cache names for Django channels
- Converted Nginx reload from a sequential task to all-appservers-in-parallel, with a 180s timeout
- Fixes for possible race conditions / other bugs in the file monitor websocket
- Forced postgresql database drop method
- Other small details which arose during production
- Some minor tweaks to tests and the development suite